### PR TITLE
Deep object copy of the initial config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export class Validation implements FormValidation {
       if (typeof config !== 'object') throw new Error('Config must be an object.');
       this.config = {
         ...this.config,
-        ...config,
+        ...this.cloneDeep(config),
       };
     }
 
@@ -593,5 +593,32 @@ export class Validation implements FormValidation {
 
     this.config.fields[fieldName] = { ...config };
     this.setupFieldConfig(fieldName, config.rules, config.messages);
+  }
+
+
+  /**
+   * Clones an object deeply.
+   * We need this method to clone the configuration object and allow us to use the same configuration object in different instances.
+   * @param {T} obj - Object to clone.
+   * @returns {T} - Cloned object.
+   */
+  cloneDeep<T>(obj: T): T {
+    if (obj === null || typeof obj !== "object") {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      const copy: any = [];
+      obj.forEach((elem, index) => {
+        copy[index] = this.cloneDeep(elem);
+      });
+      return copy;
+    }
+
+    const copy: any = {};
+    Object.keys(obj).forEach((key) => {
+      copy[key] = this.cloneDeep((obj as any)[key]);
+    });
+    return copy;
   }
 }


### PR DESCRIPTION
# Description
Implement deep cloning method for the config objects. 

This method is particularly useful in scenarios where the same configuration object needs to be used across multiple instances (e.g., initializing multiple forms with identical structure and rules) without the instances affecting each other due to shared references. Deep cloning ensures that each instance gets a completely independent copy of the configuration object.

I'm fixing this reported issue: https://github.com/ltvco/form-validation/issues/2

# Testing

1. Create a html file.
2. Create two forms with one input each.
3. Add a script to add the validation to those inputs.
4. Create a validation for each forms using the same config object.

