### PR TITLE
Adding setup script for dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,25 @@ Tips:
 - Use lowercase.
 - Avoid long branch names.
 - Be specific but not overly detailed.
+
+## Development Environment Setup
+
+After cloning the repository, you'll need to configure your local development environment:
+
+### 1. Install Dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure Development Directory
+
+The repository includes a `dev/` directory with test files and examples. To prevent your local changes to these files from being committed to the repository, run:
+
+```bash
+npm run setup
+```
+
+This command configures Git to ignore future changes to files in the `dev/` directory while keeping the original files in the repository for all contributors to use.
+
+**Note:** You only need to run this once after cloning the repository.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "webpack serve --config ./webpack.dev.js",
     "prepack": "npm run build",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "setup": "find dev/ -type f -exec git update-index --skip-worktree {} \\; && echo 'Dev environment configured: changes to dev/ files will be ignored by Git'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Adding a small `setup` script to run the first time a contributor clones the repository. This allows all contributors to freely make changes in the `/dev` directory without the changes appearing staged. By doing this, we can keep the `dev/` directory as clean as possible and avoid accidentally committing changes that are only relevant for a specific test or for a specific use case.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (non-breaking change with no user-facing impact)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [x] Configuration (changes to build setup, tooling, or CI/CD)
- [x] Chore (maintenance, code cleanup, or minor non-functional tasks)
- [ ] Test (adding or updating tests)
